### PR TITLE
Add `go.mod` for golang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
 
 script:
-  - (cd mba && go mod init mba)
+  - (cd mba && true)
   - mkdir -p build && cd build
   - cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 ..
   - make

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ddemidov/mba
+
+go 1.14


### PR DESCRIPTION
Without a `go.mod`, a `go get` works:
```
go get -u github.com/ddemidov/mba
go: downloading github.com/ddemidov/mba v0.0.0-20210614144229-15cbf8de28de
go: github.com/ddemidov/mba upgrade => v0.0.0-20210614144229-15cbf8de28de
```

however `go mod vendor` shows:
```
go mod vendor
go: finding module for package github.com/ddemidov/mba
<package> imports
	github.com/ddemidov/mba: module github.com/ddemidov/mba@latest found (v0.0.0-20210614144229-15cbf8de28de), but does not contain package github.com/ddemidov/mba
```

This PR adds a minimal `go.mod`, and removes making an ephemeral go.mod with `go mod init` in `.travis.yaml`.

Not sure where travis is deployed, so patch tries to minimally disrupt the current travis flow.