### PR TITLE
Update pybind11 to latest stable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "python/pybind11"]
 	path = python/pybind11
 	url = https://github.com/pybind/pybind11.git
+	branch = stable

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         ext_modules=[
             Extension('mba', ['python/pymba.cpp'],
                 include_dirs=['python/pybind11/include/', '.'],
-                extra_compile_args=['-O3', '-std=c++11']
+                extra_compile_args=['-O3', '-std=c++11', '-w']
                 )
             ]
 )


### PR DESCRIPTION
I had problems building a docker image based on `FROM python:3`; `mba` would not build. This was resolved by updating pybind11 to latest stable. My scripts using `mba2` seem to work flawlessly with this setup.

This PR also disables the compiler warnings in `setup.py`. This is not necessary, but made debugging easier for me. Feel free to omit this change if you feel like it.